### PR TITLE
Fixes the plugin config not outputting proper syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const appRoot = require('app-root-path')
+const appRoot = process.env.PWD || process.cwd();
 const pluginName = 'plugin-node-engine-extender'
 const configPath = 'extensionPath'
 

--- a/index.js
+++ b/index.js
@@ -39,6 +39,11 @@ function registerEvents(patternlab) {
 function getPluginFrontendConfig() {
   return {
     'name':'pattern-lab\/' + pluginName,
+    'templates': [],
+    'stylesheets': [],
+    'javascripts': [],
+    'onready': '',
+    'callback': ''
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "plugin-node-engine-extender",
+  "version": "1.0.5",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -7,13 +7,17 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "rwaymouth@gmail.com",
-  "keywords": ["Pattern Lab", "Pattern Lab Node", "plugin", "handlebars", "pattern engine" ],
+  "keywords": [
+    "Pattern Lab",
+    "Pattern Lab Node",
+    "plugin",
+    "handlebars",
+    "pattern engine"
+  ],
   "license": "ISC",
   "repository": {
     "type": "git",
     "url": "https://github.com/rwaymouth/plugin-node-engine-extender"
   },
-  "dependencies": {
-    "app-root-path": "^2.0.1"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Closes #2 - The `getPluginFrontendConfig` function was not outputting proper syntax, which caused the plugin loader to fail and throw errors to the console window. This was also causing other plugins to fail because of the errors getting thrown. This also adds a minor fix, where I was unable to use/install the package from a local folder due to the `app-root-path` package not finding the correct root directory. 